### PR TITLE
Update to Swift 5 and SwiftNIO 1.13.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "695afc5205aaa49fca092b94b479ff71c43d9d3c",
-          "version": "1.8.0"
+          "revision": "29a9f2aca71c8afb07e291336f1789337ce235dd",
+          "version": "1.13.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -6,19 +6,13 @@ import PackageDescription
 let package = Package(
     name: "SwiftDataLoader",
     products: [
-        .library(
-            name: "SwiftDataLoader",
-            targets: ["SwiftDataLoader"]),
+        .library(name: "SwiftDataLoader", targets: ["SwiftDataLoader"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "1.13.2"),
     ],
     targets: [
-        .target(
-            name: "SwiftDataLoader",
-            dependencies: ["NIO"]),
-        .testTarget(
-            name: "SwiftDataLoaderTests",
-            dependencies: ["SwiftDataLoader"]),
+        .target(name: "SwiftDataLoader", dependencies: ["NIO"]),
+        .testTarget(name: "SwiftDataLoaderTests", dependencies: ["SwiftDataLoader"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -14,5 +14,6 @@ let package = Package(
     targets: [
         .target(name: "SwiftDataLoader", dependencies: ["NIO"]),
         .testTarget(name: "SwiftDataLoaderTests", dependencies: ["SwiftDataLoader"]),
-    ]
+    ],
+    swiftLanguageVersions: [.v3, .v4, .v4_2, .version("5")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["SwiftDataLoader"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "1.8.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "1.13.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Hi,

this change makes sure the project is using Swift 5.0.0 and the latest 1.x SwiftNIO implementation. 

- I've verified that it builds correctly using CLI and Xcode 10.2
- Tests are running through
- There are no warnings popping up on build / test