### PR TITLE
feat: Add swift wasm CI targets to DataLoader

### DIFF
--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -1,0 +1,24 @@
+name: wasm
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  # NOTE: swift tests won't compile due to usage
+  # of NIOPosix. But we can at least test that wasm compilation
+  # works, to prevent future breakages.
+  wasm:
+    name: Test wasm compilation
+    runs-on: ubuntu-latest
+    container: swift:6.1.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: swiftwasm/setup-swiftwasm@v2
+        with:
+          target: "wasm32-unknown-wasip1-threads"
+      - run: swift build --swift-sdk wasm32-unknown-wasip1-threads

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "34f315fb9047f350b535493d2e79e60dfd40675b4bfc9f7a8e4b8d79bb3dd6c5",
+  "originHash" : "34ed11cdeebef1b2864a6db79a150ffe000d97cca7e36c30e30939d14f609619",
   "pins" : [
     {
       "identity" : "async-collections",
@@ -40,10 +40,10 @@
     {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/PassiveLogic/swift-nio.git",
+      "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "8d2347a56b812083fe547e584de023f2668fe6fe"
+        "revision" : "a5fea865badcb1c993c85b0f0e8d05a4bd2270fb",
+        "version" : "2.85.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
-        "version" : "1.5.0"
+        "revision" : "41daa93a5d229e1548ec86ab527ce4783ca84dda",
+        "version" : "1.6.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "34f315fb9047f350b535493d2e79e60dfd40675b4bfc9f7a8e4b8d79bb3dd6c5",
   "pins" : [
     {
       "identity" : "async-collections",
@@ -39,10 +40,10 @@
     {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
+      "location" : "https://github.com/PassiveLogic/swift-nio.git",
       "state" : {
-        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
-        "version" : "2.83.0"
+        "branch" : "main",
+        "revision" : "8d2347a56b812083fe547e584de023f2668fe6fe"
       }
     },
     {
@@ -59,10 +60,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
-        "version" : "1.4.0"
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.10.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
         .package(url: "https://github.com/adam-fowler/async-collections", from: "0.0.1"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+
+        // TODO: SM: Revert before merging. Temporarily using PL nio to test fix for NIOCore.
+        // .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/PassiveLogic/swift-nio.git", branch: "main"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
         .package(url: "https://github.com/adam-fowler/async-collections", from: "0.0.1"),
-
-        // TODO: SM: Revert before merging. Temporarily using PL nio to test fix for NIOCore.
-        // .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
-        .package(url: "https://github.com/PassiveLogic/swift-nio.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.84.0"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://img.shields.io/badge/License-MIT-blue.svg?style=flat)](https://tldrlegal.com/license/mit-license)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FGraphQLSwift%2FDataLoader%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/GraphQLSwift/DataLoader)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FGraphQLSwift%2FDataLoader%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/GraphQLSwift/DataLoader)
+[![WASI 0.1](https://github.com/GraphQLSwift/DataLoader/actions/workflows/wasm.yml/badge.svg?branch=main)](https://github.com/GraphQLSwift/DataLoader/actions/workflows/wasm.yml)
 
 DataLoader is a generic utility to be used as part of your application's data fetching layer to provide a simplified and consistent API over various remote data sources such as databases or web services via batching and caching.
 

--- a/Tests/AsyncDataLoaderTests/DataLoaderAbuseTests.swift
+++ b/Tests/AsyncDataLoaderTests/DataLoaderAbuseTests.swift
@@ -1,6 +1,5 @@
-import XCTest
-
 @testable import AsyncDataLoader
+import XCTest
 
 /// Provides descriptive error messages for API abuse
 class DataLoaderAbuseTests: XCTestCase {

--- a/Tests/AsyncDataLoaderTests/DataLoaderTests.swift
+++ b/Tests/AsyncDataLoaderTests/DataLoaderTests.swift
@@ -1,6 +1,5 @@
-import XCTest
-
 @testable import AsyncDataLoader
+import XCTest
 
 let sleepConstant = UInt64(2_000_000)
 
@@ -53,7 +52,7 @@ final class DataLoaderTests: XCTestCase {
         XCTAssertTrue(empty.isEmpty)
     }
 
-    // Batches multiple requests
+    /// Batches multiple requests
     func testMultipleRequests() async throws {
         let loadCalls = Concurrent<[[Int]]>([])
 
@@ -178,7 +177,7 @@ final class DataLoaderTests: XCTestCase {
         XCTAssertTrue(calls.map { $0.sorted() } == [[1]])
     }
 
-    // Caches repeated requests
+    /// Caches repeated requests
     func testCachesRepeatedRequests() async throws {
         let loadCalls = Concurrent<[[String]]>([])
 
@@ -399,7 +398,7 @@ final class DataLoaderTests: XCTestCase {
         XCTAssertTrue(calls2.map { $0.sorted() } == [["A", "B"], ["A", "B"]])
     }
 
-    // Allows priming the cache
+    /// Allows priming the cache
     func testAllowsPrimingTheCache() async throws {
         let loadCalls = Concurrent<[[String]]>([])
 

--- a/Tests/DataLoaderTests/DataLoaderAbuseTests.swift
+++ b/Tests/DataLoaderTests/DataLoaderAbuseTests.swift
@@ -1,7 +1,6 @@
+@testable import DataLoader
 import NIOPosix
 import XCTest
-
-@testable import DataLoader
 
 /// Provides descriptive error messages for API abuse
 class DataLoaderAbuseTests: XCTestCase {

--- a/Tests/DataLoaderTests/DataLoaderAsyncTests.swift
+++ b/Tests/DataLoaderTests/DataLoaderAsyncTests.swift
@@ -1,7 +1,6 @@
+@testable import DataLoader
 import NIOPosix
 import XCTest
-
-@testable import DataLoader
 
 #if compiler(>=5.5) && canImport(_Concurrency)
 
@@ -70,7 +69,7 @@ import XCTest
             XCTAssertTrue(empty.isEmpty)
         }
 
-        // Batches multiple requests
+        /// Batches multiple requests
         func testMultipleRequests() async throws {
             let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
             defer {
@@ -96,8 +95,8 @@ import XCTest
             async let value1 = identityLoader.load(key: 1, on: eventLoopGroup)
             async let value2 = identityLoader.load(key: 2, on: eventLoopGroup)
 
-            /// Have to wait for a split second because Tasks may not be executed before this
-            /// statement
+            // Have to wait for a split second because Tasks may not be executed before this
+            // statement
             try await Task.sleep(nanoseconds: 500_000_000)
 
             XCTAssertNoThrow(try identityLoader.execute())

--- a/Tests/DataLoaderTests/DataLoaderTests.swift
+++ b/Tests/DataLoaderTests/DataLoaderTests.swift
@@ -1,8 +1,7 @@
+@testable import DataLoader
 import NIOCore
 import NIOPosix
 import XCTest
-
-@testable import DataLoader
 
 /// Primary API
 final class DataLoaderTests: XCTestCase {
@@ -48,7 +47,7 @@ final class DataLoaderTests: XCTestCase {
         XCTAssertTrue(empty.isEmpty)
     }
 
-    // Batches multiple requests
+    /// Batches multiple requests
     func testMultipleRequests() throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
@@ -144,7 +143,7 @@ final class DataLoaderTests: XCTestCase {
         XCTAssertTrue(loadCalls == [[1]])
     }
 
-    // Caches repeated requests
+    /// Caches repeated requests
     func testCachesRepeatedRequests() throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
@@ -270,7 +269,7 @@ final class DataLoaderTests: XCTestCase {
         XCTAssertTrue(loadCalls == [["A", "B"], ["A", "B"]])
     }
 
-    // Allows priming the cache
+    /// Allows priming the cache
     func testAllowsPrimingTheCache() throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {
@@ -384,7 +383,7 @@ final class DataLoaderTests: XCTestCase {
         XCTAssertTrue(loadCalls == [["B"]])
     }
 
-    // Caches repeated requests, even if initiated asyncronously
+    /// Caches repeated requests, even if initiated asyncronously
     func testCacheConcurrency() throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {


### PR DESCRIPTION
# Change summary

Added swift wasm as a CI target, to help prevent future breakages to swift wasm builds in DataLoader

# Details

- Added ci stage that checks wasm compilation.
- Temporarily pointing to a branch of swift-nio to verify wasm compilation, as swift-nio/NIOCore is currently broken. The swift-nio version will be bumped before merging this.
- Bump swift version from 5.8 to 5.10.0, which is the new minimum for the latest swift-nio dependency.
- Add wasi 0.1 build status badge to README.md.

# Notes

- Because the build status badge uses an unmerged workflow (.github/workflows/wasm.yaml), it can't be tested until this PR is merged. Some follow-on work may be needed after merging to ensure proper badge functionality.
- This PR is [part of a larger effort](https://github.com/PassiveLogic/swift-web-examples/issues/1) by PassiveLogic to add wasm support to many popular repositories.

# PR Dependencies

The following PR's must be merged before this PR can be merged:

- https://github.com/GraphQLSwift/ci/pull/3
- https://github.com/apple/swift-nio/pull/3271

# Testing done

Verified new github workflow builds, once required upstream dependencies are patched in swift-nio

See https://github.com/PassiveLogic/DataLoader/actions/runs/15833601501/job/44631947127?pr=1

Latest test results as of 2026 here:

https://github.com/PassiveLogic/DataLoader/pull/2

Note that there are some lint errors from files not modified in this branch. Likely those lint errors are already in the latest `main`.

# Remaining work

- [x] Update this PR after swift-nio wasm build is merged and released
- [ ] After merging, verify badge works as expected. As noted, this can't be tested until after merging. Submit patch for new badge if needed.
