### PR TITLE
docs: Remove Wasm badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![](https://img.shields.io/badge/License-MIT-blue.svg?style=flat)](https://tldrlegal.com/license/mit-license)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FGraphQLSwift%2FDataLoader%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/GraphQLSwift/DataLoader)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FGraphQLSwift%2FDataLoader%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/GraphQLSwift/DataLoader)
-[![WASI 0.1](https://github.com/GraphQLSwift/DataLoader/actions/workflows/wasm.yml/badge.svg?branch=main)](https://github.com/GraphQLSwift/DataLoader/actions/workflows/wasm.yml)
 
 DataLoader is a generic utility to be used as part of your application's data fetching layer to provide a simplified and consistent API over various remote data sources such as databases or web services via batching and caching.
 


### PR DESCRIPTION
The previous line in the README includes a wasm badge now, and this badge image didn't work. Best course of action is to just remove the new badge to avoid duplicate information.