### PR TITLE
Adds Benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ iOSInjectionProject/
 
 # VS Code
 .vscode/
+
+.DS_Store

--- a/Benchmarks/Benchmarks/DataLoaderBenchmarks.swift
+++ b/Benchmarks/Benchmarks/DataLoaderBenchmarks.swift
@@ -1,0 +1,99 @@
+import Benchmark
+import NIO
+import AsyncDataLoader
+import DataLoader
+
+let eventLoopGroup = MultiThreadedEventLoopGroup.singleton
+
+let benchmarks: @Sendable () -> Void = {
+
+    // MARK: Async
+
+    let nonBatchingLoader = DataLoader<Int, Int>(
+        options: .init(
+            batchingEnabled: true,
+            cachingEnabled: false,
+        )
+    ) { keys in
+        keys.map { DataLoaderValue.success($0) }
+    }
+
+    let batchingLoader = DataLoader<Int, Int>(
+        options: .init(
+            batchingEnabled: true,
+            cachingEnabled: false,
+            maxBatchSize: 10
+        )
+    ) { keys in
+        keys.map { DataLoaderValue.success($0) }
+    }
+
+    Benchmark("loadNonBatching") { _ in
+        try await withThrowingTaskGroup { group in
+            for i in (0..<1_000) {
+                group.addTask {
+                    try await nonBatchingLoader.load(key: i)
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    Benchmark("loadBatching") { _ in
+        try await withThrowingTaskGroup { group in
+            for i in (0..<1_000) {
+                group.addTask {
+                    try await batchingLoader.load(key: i)
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    Benchmark("loadBatchingMany") { _ in
+        let result = try await batchingLoader.loadMany(keys: Array(0..<1_000))
+    }
+
+    // MARK: NIO
+
+    let nioNonBatchingLoader = DataLoader<Int, Int>(
+        options: .init(
+            batchingEnabled: true,
+            cachingEnabled: false,
+        )
+    ) { keys in
+        return eventLoopGroup.next().makeSucceededFuture(
+            keys.map { DataLoaderFutureValue.success($0) }
+        )
+    }
+
+    let nioBatchingLoader = DataLoader<Int, Int>(
+        options: .init(
+            batchingEnabled: true,
+            cachingEnabled: false,
+            maxBatchSize: 10
+        )
+    ) { keys in
+        return eventLoopGroup.next().makeSucceededFuture(
+            keys.map { DataLoaderFutureValue.success($0) }
+        )
+    }
+
+    Benchmark("nioLoadNonBatching") { _ in
+        let futures = try (0..<1_000).map { i in
+            try nioNonBatchingLoader.load(key: i, on: eventLoopGroup.next())
+        }
+        let result = try EventLoopFuture.whenAllSucceed(futures, on: eventLoopGroup.next()).wait()
+    }
+
+    Benchmark("nioLoadBatching") { _ in
+        let futures = try (0..<1_000).map { i in
+            try nioBatchingLoader.load(key: i, on: eventLoopGroup.next())
+        }
+        let result = try EventLoopFuture.whenAllSucceed(futures, on: eventLoopGroup.next()).wait()
+    }
+
+    Benchmark("nioLoadBatchingMany") { _ in
+        let result = try nioBatchingLoader.loadMany(keys: Array(0..<1_000), on: eventLoopGroup.next()).wait()
+    }
+}

--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -1,0 +1,113 @@
+{
+  "pins" : [
+    {
+      "identity" : "async-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/async-collections",
+      "state" : {
+        "revision" : "726af96095a19df6b8053ddbaed0a727aa70ccb2",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "hdrhistogram-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/HdrHistogram/hdrhistogram-swift.git",
+      "state" : {
+        "revision" : "93a1618c8aa20f6a521a9da656a3e0591889e9dc",
+        "version" : "0.1.3"
+      }
+    },
+    {
+      "identity" : "package-benchmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/package-benchmark",
+      "state" : {
+        "revision" : "acfd97b98f5a40d963c89437e1cfaeab8ef10bf9",
+        "version" : "1.29.7"
+      }
+    },
+    {
+      "identity" : "package-jemalloc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/package-jemalloc.git",
+      "state" : {
+        "revision" : "e8a5db026963f5bfeac842d9d3f2cc8cde323b49",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "cd6710454f25733900e133c6caf5188952763c36",
+        "version" : "2.98.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
+        "version" : "1.6.3"
+      }
+    },
+    {
+      "identity" : "texttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/TextTable.git",
+      "state" : {
+        "revision" : "a27a07300cf4ae322e0079ca0a475c5583dd575f",
+        "version" : "0.0.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.10
+import PackageDescription
+
+let package = Package(
+    name: "Benchmarks",
+    platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(name: "DataLoader", path: "../"),
+        .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.4.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.84.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Benchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "AsyncDataLoader", package: "DataLoader"),
+                .product(name: "DataLoader", package: "DataLoader"),
+                .product(name: "NIO", package: "swift-nio"),
+            ],
+            path: "Benchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
Initial output:

```
=====================================================================================================
Baseline 'Current_run'
=====================================================================================================

Host 'JaysLaptop.local' with 11 'arm64' processors with 18 GB memory, running:
Darwin Kernel Version 25.3.0: Wed Jan 28 20:54:22 PST 2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T6030

==========
Benchmarks
==========

loadBatching
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (M) *            │        57 │        67 │        69 │        70 │        72 │        82 │        87 │       190 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) (K) *          │        11 │        14 │        15 │        17 │        19 │        22 │        22 │       190 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        16 │        31 │        32 │        33 │        37 │        38 │        38 │       190 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (#)        │       256 │       196 │       192 │       190 │       187 │       165 │       163 │       190 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (μs) *       │      4256 │      6283 │      6513 │      6922 │      7217 │     10011 │     10836 │       190 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) *      │      3901 │      5112 │      5198 │      5267 │      5345 │      6054 │      6128 │       190 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

loadBatchingMany
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (M) *            │        67 │        75 │        75 │        77 │        78 │        87 │        88 │       186 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) (K) *          │        14 │        18 │        19 │        21 │        22 │        27 │        27 │       186 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        18 │        33 │        35 │        36 │        36 │        36 │        36 │       186 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (#)        │       232 │       190 │       187 │       186 │       185 │       177 │       167 │       186 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (μs) *       │      5239 │      7057 │      7229 │      7926 │      8196 │      9191 │      9461 │       186 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) *      │      4307 │      5272 │      5333 │      5382 │      5419 │      5657 │      5984 │       186 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

loadNonBatching
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (M) *            │        57 │        67 │        69 │        70 │        72 │        84 │        84 │       192 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) (K) *          │        10 │        14 │        15 │        17 │        18 │        21 │        21 │       192 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        16 │        31 │        34 │        38 │        38 │        39 │        39 │       192 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (#)        │       261 │       197 │       193 │       191 │       190 │       178 │       175 │       192 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (μs) *       │      4552 │      6513 │      6648 │      6832 │      7381 │      8782 │      8956 │       192 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) *      │      3824 │      5071 │      5177 │      5231 │      5263 │      5624 │      5729 │       192 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

nioLoadBatching
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (M) *            │        72 │        78 │        78 │        79 │        80 │        82 │        82 │       267 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) (K) *          │        12 │        13 │        14 │        15 │        19 │        28 │        33 │       267 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        17 │        24 │        26 │        26 │        26 │        26 │        26 │       267 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (#)        │       317 │       286 │       278 │       265 │       254 │       238 │       231 │       267 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (ms) *       │        11 │        13 │        14 │        16 │        16 │        18 │        19 │       267 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) *      │      3154 │      3502 │      3592 │      3774 │      3942 │      4211 │      4320 │       267 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

nioLoadBatchingMany
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (M) *            │        37 │        37 │        40 │        41 │        42 │        44 │        45 │       276 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) (K) *          │         8 │        10 │        12 │        12 │        20 │        29 │        30 │       276 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        17 │        24 │        24 │        24 │        25 │        25 │        25 │       276 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (#)        │       332 │       296 │       290 │       282 │       276 │       207 │       159 │       276 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (μs) *       │      2673 │      3647 │      4014 │      6623 │      7688 │      9019 │      9668 │       276 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) *      │      3015 │      3369 │      3453 │      3549 │      3623 │      4829 │      6277 │       276 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

nioLoadNonBatching
╒═══════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│ Metric                        │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞═══════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│ Instructions (M) *            │        72 │        83 │        83 │        83 │        84 │        86 │        87 │       226 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Malloc (total) (K) *          │        11 │        12 │        13 │        14 │        20 │        26 │        27 │       226 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Memory (resident peak) (M)    │        17 │        23 │        25 │        25 │        25 │        25 │        25 │       226 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Throughput (# / s) (#)        │       258 │       238 │       234 │       229 │       223 │       204 │       198 │       226 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (total CPU) (ms) *       │        10 │        13 │        14 │        14 │        15 │        16 │        19 │       226 │
├───────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│ Time (wall clock) (μs) *      │      3881 │      4211 │      4280 │      4362 │      4485 │      4915 │      5062 │       226 │
╘═══════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```