### PR TITLE
Restore AsyncCollections dependency

### DIFF
--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -1,6 +1,14 @@
 {
-  "originHash" : "291df3327aad87228cf28f3cc39ec8b92e332c285db9b81b29cb92cb71d46837",
   "pins" : [
+    {
+      "identity" : "async-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/async-collections",
+      "state" : {
+        "revision" : "726af96095a19df6b8053ddbaed0a727aa70ccb2",
+        "version" : "0.1.0"
+      }
+    },
     {
       "identity" : "hdrhistogram-swift",
       "kind" : "remoteSourceControl",
@@ -101,5 +109,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "cd234e013443e6dda35a41eb3c534540f5fa8abb6b1146f8037e768f237caa39",
+  "originHash" : "34ed11cdeebef1b2864a6db79a150ffe000d97cca7e36c30e30939d14f609619",
   "pins" : [
+    {
+      "identity" : "async-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/async-collections",
+      "state" : {
+        "revision" : "726af96095a19df6b8053ddbaed0a727aa70ccb2",
+        "version" : "0.1.0"
+      }
+    },
     {
       "identity" : "swift-algorithms",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
+        .package(url: "https://github.com/adam-fowler/async-collections", from: "0.0.1"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.84.0"),
     ],
     targets: [
@@ -26,6 +27,7 @@ let package = Package(
             name: "AsyncDataLoader",
             dependencies: [
                 .product(name: "Algorithms", package: "swift-algorithms"),
+                .product(name: "AsyncCollections", package: "async-collections"),
             ]
         ),
         .testTarget(

--- a/Sources/AsyncDataLoader/DataLoader.swift
+++ b/Sources/AsyncDataLoader/DataLoader.swift
@@ -173,7 +173,7 @@ public actor DataLoader<Key: Hashable & Sendable, Value: Sendable> {
         // If a maxBatchSize was provided and the queue is longer, then segment the
         // queue into multiple batches, otherwise treat the queue as a single batch.
         if let maxBatchSize = options.maxBatchSize, maxBatchSize > 0, maxBatchSize < batch.count {
-            try await batch.chunks(ofCount: maxBatchSize).asyncForEach { slicedBatch in
+            for slicedBatch in batch.chunks(ofCount: maxBatchSize) {
                 try await self.executeBatch(batch: Array(slicedBatch))
             }
         } else {

--- a/Sources/AsyncDataLoader/DataLoader.swift
+++ b/Sources/AsyncDataLoader/DataLoader.swift
@@ -1,4 +1,5 @@
 import Algorithms
+import AsyncCollections
 
 public enum DataLoaderValue<T: Sendable>: Sendable {
     case success(T)
@@ -116,19 +117,7 @@ public actor DataLoader<Key: Hashable & Sendable, Value: Sendable> {
             return []
         }
 
-        // This buffer pointer allows us to initialize a pre-sized non-nullable list
-        // that we can populate by index as `load` results stream in asyncronously
-        let buffer = UnsafeMutableBufferPointer<Value>.allocate(capacity: keys.count)
-        try await withThrowingTaskGroup { group in
-            for (index, element) in keys.enumerated() {
-                group.addTask {
-                    let result = try await self.load(key: element)
-                    buffer[index] = result
-                }
-            }
-            try await group.waitForAll()
-        }
-        return Array(buffer)
+        return try await keys.concurrentMap { try await self.load(key: $0) }
     }
 
     /// Clears the value at `key` from the cache, if it exists. Returns itself for
@@ -184,7 +173,7 @@ public actor DataLoader<Key: Hashable & Sendable, Value: Sendable> {
         // If a maxBatchSize was provided and the queue is longer, then segment the
         // queue into multiple batches, otherwise treat the queue as a single batch.
         if let maxBatchSize = options.maxBatchSize, maxBatchSize > 0, maxBatchSize < batch.count {
-            for slicedBatch in batch.chunks(ofCount: maxBatchSize) {
+            try await batch.chunks(ofCount: maxBatchSize).asyncForEach { slicedBatch in
                 try await self.executeBatch(batch: Array(slicedBatch))
             }
         } else {


### PR DESCRIPTION
The [new implementation of `loadMany`](https://github.com/GraphQLSwift/DataLoader/blob/6e6142359f16d20a6fa119dbf95f9f2d85ef9747/Sources/AsyncDataLoader/DataLoader.swift#L121) suffered from memory crashes (at least on Linux systems) when setting indices in the mutable buffer from different tasks.

It turns out Adam Fowler is smart and we're lucky to have him. He deserves a raise.

This reverts commit 12b481e10848a6da6c0a6ad37b2bd0b1c87ea941.